### PR TITLE
Add "counter" metric suport to "NewValueFromMetric()" API

### DIFF
--- a/value_metric.go
+++ b/value_metric.go
@@ -46,6 +46,10 @@ func (c *ValueFromMetric) ValueFloat() float64 {
 		if model.Gauge != nil && model.Gauge.Value != nil {
 			firstValue = model.Gauge.Value
 		}
+
+		if model.Counter != nil && model.Counter.Value != nil {
+			firstValue = model.Counter.Value
+		}
 	}
 
 	if firstValue != nil {


### PR DESCRIPTION
For some reason `NewValueFromMetric()` only works with gauges. So when you use it on counters you would always get "0". 

This caused logging zeroes in the [sql sink here](https://github.com/streamingfast/substreams-sink-sql/blob/90756a23d606b8a75e09d9de37236debc6030cf4/sinker/stats.go#L74) or [kv sink here](https://github.com/streamingfast/substreams-sink-kv/blob/ce36f7d642e1d22f18cc773c83e5ef15dd913432/sinker/stats.go#L36) for example

Don't see why it can't work with counters too. This PR adds that.